### PR TITLE
Allow Stripe monad to be used as a base in transformer stack

### DIFF
--- a/src/Web/Stripe/Client/Types.hs
+++ b/src/Web/Stripe/Client/Types.hs
@@ -22,7 +22,7 @@ import           Web.Stripe.Client.Error    (StripeError (..))
 
 ------------------------------------------------------------------------------
 -- | The `Stripe` Monad
-type Stripe a = EitherT StripeError (ReaderT (StripeConfig, Connection) IO) a
+type Stripe = EitherT StripeError (ReaderT (StripeConfig, Connection) IO)
 
 ------------------------------------------------------------------------------
 -- | HTTP Params


### PR DESCRIPTION
The current definition prevents Stripe from being used as a base monad because GHC complains about the type synonym missing a type parameter. This should allow for more flexible use of the Stripe monad.

For example, I'm wiring up pipes to the API, and can't currently write this:

```
allCustomers :: Producer [Customer] Stripe ()
```