### PR TITLE
Added Maybe PlanId to updateSubscription

### DIFF
--- a/src/Web/Stripe/Subscription.hs
+++ b/src/Web/Stripe/Subscription.hs
@@ -150,17 +150,20 @@ updateSubscription
     :: CustomerId      -- ^ The `CustomerId` of the `Subscription` to update
     -> SubscriptionId  -- ^ The `SubscriptionId` of the `Subscription` to update
     -> Maybe CouponId  -- ^ Optional: The `Coupon` of the `Subscription` to update
+    -> Maybe PlanId    -- ^ Optional: The id `Plan` to switch the `Subscription` to
     -> MetaData
     -> Stripe Subscription
 updateSubscription
     customerid
     (SubscriptionId subscriptionid)
     couponid
+    planid
     metadata    = callAPI request
   where request = StripeRequest POST url params
         url     = "customers" </> getCustomerId customerid </> "subscriptions" </> subscriptionid
         params  = toMetaData metadata ++ getParams [
-           ("coupon", (\(CouponId x) -> x) `fmap` couponid)
+            ("coupon", (\(CouponId x) -> x) `fmap` couponid)
+          , ("plan",   (\(PlanId x) -> x) `fmap` planid)
           ]
 
 ------------------------------------------------------------------------------

--- a/stripe-haskell.cabal
+++ b/stripe-haskell.cabal
@@ -1,5 +1,5 @@
 name:                stripe-haskell
-version:             0.1.2.2
+version:             0.1.3.0
 synopsis:            Stripe API for Haskell
 license:             MIT
 license-file:        LICENSE

--- a/tests/Test/Discount.hs
+++ b/tests/Test/Discount.hs
@@ -93,7 +93,7 @@ discountTests config = do
             []
         Subscription { subscriptionId = sid } <-
           createSubscription customerid plan []
-        void $ updateSubscription customerid sid (Just coupon) []
+        void $ updateSubscription customerid sid (Just coupon) Nothing []
         result <- deleteSubscriptionDiscount customerid sid
         void $ deletePlan planid
         void $ deleteCustomer customerid

--- a/tests/Test/Subscription.hs
+++ b/tests/Test/Subscription.hs
@@ -99,6 +99,7 @@ subscriptionTests config = do
       result `shouldSatisfy` isRight
     it "Succesfully updates a Customer's Subscriptions" $ do
       planid <- makePlanId
+      secondPlanid <- makePlanId
       couponid <- makeCouponId
       result <- stripe config $ do
         Coupon { } <-
@@ -119,9 +120,17 @@ subscriptionTests config = do
                         Month
                         "sample plan"
                         []
+        void $ createPlan secondPlanid
+                        0 -- free plan
+                        USD
+                        Year
+                        "second sample plan"
+                        []
         Subscription { subscriptionId = sid } <- createSubscription cid planid []
-        sub <- updateSubscription cid sid (Just couponid) [("hi","there")]
+        _ <- updateSubscription cid sid (Just couponid) Nothing [("hi","there")]
+        sub <- updateSubscription cid sid (Just couponid) (Just secondPlanid) [("hi","there")]
         void $ deletePlan planid
+        void $ deletePlan secondPlanid
         void $ deleteCustomer cid
         return sub
       result `shouldSatisfy` isRight


### PR DESCRIPTION
Partial solution to #10 .  I know that there is a big rework of API parameters in a separate pull request ( #11 ) but it seems like that has stalled.  In the mean time, this will allow `updateSubscription` to be used to update plans.  I update the test code and the relevant section passes.  