### PR TITLE
URL encode form params in x-www-form-urlencode POST body.

### DIFF
--- a/tests/Test/Raw.hs
+++ b/tests/Test/Raw.hs
@@ -3,9 +3,12 @@ module Test.Raw (rawTest) where
 
 import           Data.Aeson
 import           Data.Either
+import           Data.Monoid         ((<>))
+import           Data.Text           (Text)
+import qualified Data.Text.Encoding  as T
+import           Network.Http.Client
 import           Test.Hspec
 import           Web.Stripe
-import           Network.Http.Client
 
 rawTest :: StripeConfig -> Spec
 rawTest config = do
@@ -13,8 +16,22 @@ rawTest config = do
     it "Succesfully retrieves account information" $ do
       result <- (stripeRaw config req) :: IO (Either StripeError Value)
       result `shouldSatisfy` isRight
+    it "Succesfully encodes x-www-form-urlencoded data" $ do
+      let pid = "encoded"
+      -- Add form data to the request with special characters
+      result <- (stripeRaw config (req2 pid)) :: IO (Either StripeError Value)
+      result `shouldSatisfy` isRight
+      del <- (stripeRaw config (delReq2 pid)) :: IO (Either StripeError Value)
+      del `shouldSatisfy` isRight
   where
-    req :: StripeRequest 
+    req :: StripeRequest
     req = StripeRequest GET "events" []
-
-                   
+    req2 :: Text -> StripeRequest
+    req2 pid = StripeRequest POST "plans" [ ("amount", "2000")
+                                          , ("interval", "month")
+                                          , ("name","<Acme & Co. Gold Plan+>" )
+                                          , ("currency","usd" )
+                                          , ("id", T.encodeUtf8 pid)
+                                          ]
+    delReq2 :: Text -> StripeRequest
+    delReq2 pid = StripeRequest DELETE ("plans/" <> pid) []


### PR DESCRIPTION
Today I ran into an issue with special characters in a request. For example:

If I call the `createCustomerBase` function with an '&' in the Description field, the POST body is incorrectly formatted.

I noticed the API is using x-www-form-urlencoded but not encoding the parameters: https://github.com/dmjio/stripe/blob/859dde23aaad776763c55ef4015c01eaff225f8e/src/Web/Stripe/Client/Util.hs#L50


The ruby library encodes the strings: https://github.com/stripe/stripe-ruby/blob/782a596c8f01060d22b44151e9dbd60a8ef138d6/lib/stripe.rb#L120. I believe the Python library url encodes requests as well. 

I've included a test case using the raw API which will fail without the `encodedFormBody` function. I believe the behavior of `encodedFormBody` is very similar to the `Builder.fromByteString` and `inputStreamBody` but let me know if I missed something.

One other thing to mention is it looks like this behavior might have been in the codebase before, @b5f41e9.
