### PR TITLE
Update travis build to support multiple ghc versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,29 @@
-env: STRIPEKEY=sk_test_igoYowTqR5IfovOKFKwigRmW
 language: haskell
-ghc: 7.8.3
-cabal: 1.20.0.3
+env:
+ #- GHCVER=7.4.2 CABALVER=1.18
+ - GHCVER=7.6.3 CABALVER=1.18
+ - GHCVER=7.8.4 CABALVER=1.18
+ - GHCVER=7.10.1 CABALVER=1.22
+ - GHCVER=head  CABALVER=head
+
+matrix:
+  allow_failures:
+   - env: GHCVER=7.10.1 CABALVER=1.22
+   - env: GHCVER=head  CABALVER=head
+
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
+ - cabal --version
+ - cabal install happy alex
+
+install:
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests
+
+script:
+ - cabal configure --enable-tests
+ - cabal build
+ - cabal test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
  - GHCVER=7.8.4 CABALVER=1.18
  - GHCVER=7.10.1 CABALVER=1.22
  - GHCVER=head  CABALVER=head
+ - STRIPEKEY=sk_test_igoYowTqR5IfovOKFKwigRm
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Allowed failures for GHC 7.10 and GHC HEAD.