### PR TITLE
fix example in to use correct config constructor

### DIFF
--- a/stripe-haskell/src/Web/Stripe.hs
+++ b/stripe-haskell/src/Web/Stripe.hs
@@ -14,7 +14,7 @@
 --
 -- main :: IO ()
 -- main = do
---   let config = SecretKey "secret_key"
+--   let config = StripeConfig "secret_key"
 --   result <- stripe config getAccountDetails
 --   case result of
 --     Right details -> print details


### PR DESCRIPTION
It looks like there is a typo on one of the examples in the docs, SecretKey does not seem to exist, but StripeConfig appears to do what this wants