### PR TITLE
Use latest version of stack in travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ before_install:
  - export PATH=/opt/ghc/$GHCVER/bin:$PATH
  # stack
  - mkdir -p ~/.local/bin
- - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.4.0/stack-0.1.4.0-x86_64-linux.tar.gz | tar -xvzf -
- - mv stack ~/.local/bin
+ - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
  - export PATH=~/.local/bin:$PATH
 
 install:


### PR DESCRIPTION
As suggested in the [stack guide](https://github.com/commercialhaskell/stack/blob/master/doc/GUIDE.md#travis-with-caching)