### PR TITLE
Use correct type for invoiceItemSubscription

### DIFF
--- a/stripe-core/src/Web/Stripe/Types.hs
+++ b/stripe-core/src/Web/Stripe/Types.hs
@@ -538,6 +538,12 @@ newtype SubscriptionId = SubscriptionId { getSubscriptionId :: Text }
     deriving (Read, Show, Eq, Ord, Data, Typeable)
 
 ------------------------------------------------------------------------------
+-- | JSON Instance for `SubscriptionId`
+instance FromJSON SubscriptionId where
+    parseJSON (String x)   = pure (SubscriptionId x)
+    parseJSON _            = mzero
+
+------------------------------------------------------------------------------
 -- | Subscription Object
 data Subscription = Subscription {
       subscriptionId                    :: SubscriptionId
@@ -919,7 +925,7 @@ data InvoiceItem = InvoiceItem {
     , invoiceItemDescription  :: Maybe Description
     , invoiceItemInvoice      :: Maybe (Expandable InvoiceId)
     , invoiceItemQuantity     :: Maybe Quantity
-    , invoiceItemSubscription :: Maybe Subscription
+    , invoiceItemSubscription :: Maybe SubscriptionId
     , invoiceItemMetaData     :: MetaData
     } deriving (Read, Show, Eq, Ord, Data, Typeable)
 


### PR DESCRIPTION
Running

```
stripe (StripeConfig (StripeKey "xxx")) $ getInvoiceItems -&- CustomerId "xxx"
```

gives

```
Left (StripeError {errorType = ParseFailure, errorMsg = "mzero", errorCode = Nothing, errorParam = Nothing, errorHTTP = Nothing})
```

I tracked this down to the `invoiceItemSubscription` entry on [InvoiceItem](https://hackage.haskell.org/package/stripe-core-2.1.0/docs/Web-Stripe-InvoiceItem.html#t:InvoiceItem). If you look at the stripe API for invoice items https://stripe.com/docs/api#invoiceitem_object,
the subscription value of an invoice item is the subscriptionId as a string.  But the type of
`invoiceItemSubscription` field is `Subscription` so we are trying to parse a string like "sub_xxxx"
into a Subscription.  To fix tis, the type of `invoiceItemSubscription` must change to `SubscriptionId`
and `SubscriptionId` needs a `FromJSON` instance.
