### PR TITLE
Bump aeson upper bound to 1.1.*

### DIFF
--- a/stripe-core/stripe-core.cabal
+++ b/stripe-core/stripe-core.cabal
@@ -20,7 +20,7 @@ Description:
 
 library
   hs-source-dirs:      src
-  build-depends:       aeson                >= 0.8   && < 0.10 || == 0.11.*
+  build-depends:       aeson                >= 0.8 && < 0.10 || >= 0.11 && < 1.1
                      , base                 >= 4.7   && < 5
                      , bytestring           >= 0.10  && < 0.11
                      , mtl                  >= 2.1.2 && < 2.3

--- a/stripe-http-streams/stripe-http-streams.cabal
+++ b/stripe-http-streams/stripe-http-streams.cabal
@@ -22,7 +22,7 @@ library
   exposed-modules:     Web.Stripe.Client.HttpStreams
   other-extensions:    OverloadedStrings, RecordWildCards
   build-depends:         base         >= 4.7  && < 5
-                       , aeson        >= 0.8  && < 0.10 || == 0.11.*
+                       , aeson        >= 0.8 && < 0.10 || >= 0.11 && < 1.1
                        , bytestring   >= 0.10 && < 0.11
                        , HsOpenSSL    >= 0.11 && < 0.12
                        , http-streams >= 0.7  && < 0.9

--- a/stripe-tests/stripe-tests.cabal
+++ b/stripe-tests/stripe-tests.cabal
@@ -22,7 +22,7 @@ Description:
 
 library
   hs-source-dirs:      tests
-  build-depends:       aeson        >= 0.8  && < 0.10 || == 0.11.*
+  build-depends:       aeson                >= 0.8 && < 0.10 || >= 0.11 && < 1.1
                      , base                 >= 4.7   && < 5
                      , bytestring           >= 0.10  && < 0.11
                      , free                 >= 4.10  && < 4.13


### PR DESCRIPTION
This makes it compatible with the latest stackage nightly (`nightly-2016-10-26`).