### PR TITLE
Add Prorate param to CreateSubscription

### DIFF
--- a/stripe-core/src/Web/Stripe/Subscription.hs
+++ b/stripe-core/src/Web/Stripe/Subscription.hs
@@ -107,6 +107,7 @@ createSubscription
 data CreateSubscription
 type instance StripeReturn CreateSubscription = Subscription
 instance StripeHasParam CreateSubscription CouponId
+instance StripeHasParam CreateSubscription Prorate
 instance StripeHasParam CreateSubscription TrialEnd
 instance StripeHasParam CreateSubscription CardId
 instance StripeHasParam CreateSubscription Quantity


### PR DESCRIPTION
Looking at the [stripe docs](https://stripe.com/docs/api/node#create_subscription-prorate), `prorate` appears to be a valid parameter for the `CreateSubscription` API.