### PR TITLE
making `has_more` optional

### DIFF
--- a/stripe-core/src/Web/Stripe/Types.hs
+++ b/stripe-core/src/Web/Stripe/Types.hs
@@ -20,7 +20,7 @@ import           Control.Applicative (pure, (<$>), (<*>), (<|>))
 import           Control.Monad       (mzero)
 import           Data.Aeson          (FromJSON (parseJSON), ToJSON(..),
                                       Value (String, Object, Bool), (.:),
-                                      (.:?))
+                                      (.:?), (.!=))
 import           Data.Data           (Data, Typeable)
 import qualified Data.HashMap.Strict as H
 import           Data.Ratio          ((%))
@@ -1975,7 +1975,7 @@ instance FromJSON a => FromJSON (StripeList a) where
                    <*> o .:  "url"
                    <*> o .:  "object"
                    <*> o .:? "total_count"
-                   <*> o .:  "has_more"
+                   <*> o .:?  "has_more" .!= False
     parseJSON _ = mzero
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
`has_more` field in stripe lists seems to be optional. I could not find any changes to [Stripe API](https://stripe.com/docs/upgrades) in this regard.
This pull request will fix parsing failures for most webhook events.