### PR TITLE
Retrieve all subscriptions

### DIFF
--- a/stripe-core/src/Web/Stripe/Subscription.hs
+++ b/stripe-core/src/Web/Stripe/Subscription.hs
@@ -51,6 +51,8 @@ module Web.Stripe.Subscription
     , cancelSubscription
     , GetSubscriptions
     , getSubscriptions
+    , GetSubscriptionsByCustomerId
+    , getSubscriptionsByCustomerId
       -- * Types
     , ApplicationFeePercent (..)
     , AtPeriodEnd        (..)
@@ -194,3 +196,21 @@ instance StripeHasParam GetSubscriptions ExpandParams
 instance StripeHasParam GetSubscriptions (EndingBefore SubscriptionId)
 instance StripeHasParam GetSubscriptions Limit
 instance StripeHasParam GetSubscriptions (StartingAfter SubscriptionId)
+
+------------------------------------------------------------------------------
+-- | Retrieve a customer's `Subscription`s
+getSubscriptionsByCustomerId
+    :: CustomerId
+    -> StripeRequest GetSubscriptionsByCustomerId
+getSubscriptionsByCustomerId
+    customerid = request
+  where request = mkStripeRequest GET url params
+        url     = "customers" </> getCustomerId customerid </> "subscriptions"
+        params  = []
+
+data GetSubscriptionsByCustomerId
+type instance StripeReturn GetSubscriptionsByCustomerId = StripeList Subscription
+instance StripeHasParam GetSubscriptionsByCustomerId ExpandParams
+instance StripeHasParam GetSubscriptionsByCustomerId (EndingBefore SubscriptionId)
+instance StripeHasParam GetSubscriptionsByCustomerId Limit
+instance StripeHasParam GetSubscriptionsByCustomerId (StartingAfter SubscriptionId)

--- a/stripe-core/src/Web/Stripe/Subscription.hs
+++ b/stripe-core/src/Web/Stripe/Subscription.hs
@@ -179,14 +179,13 @@ instance StripeHasParam CancelSubscription AtPeriodEnd
 type instance StripeReturn CancelSubscription = Subscription
 
 ------------------------------------------------------------------------------
--- | Retrieve active `Subscription`s
+-- | Retrieve all active `Subscription`s
 getSubscriptions
-    :: CustomerId                   -- ^ The `CustomerId` of the `Subscription`s to retrieve
-    -> StripeRequest GetSubscriptions
+    :: StripeRequest GetSubscriptions
 getSubscriptions
-  customerid = request
+    = request
   where request = mkStripeRequest GET url params
-        url     = "customers" </> getCustomerId customerid </> "subscriptions"
+        url     = "subscriptions"
         params  = []
 
 data GetSubscriptions

--- a/stripe-tests/tests/Web/Stripe/Test/Subscription.hs
+++ b/stripe-tests/tests/Web/Stripe/Test/Subscription.hs
@@ -62,6 +62,36 @@ subscriptionTests stripe = do
         void $ deleteCustomer cid
         return sub
       result `shouldSatisfy` isRight
+    it "Succesfully retrieves a Customer's Subscriptions expanded" $ do
+      planid <- makePlanId
+      result <- stripe $ do
+        Customer { customerId = cid } <- createCustomer
+        void $ createPlan planid
+                        (Amount 0) -- free plan
+                        USD
+                        Month
+                        (PlanName "sample plan")
+        void $ createSubscription cid planid
+        sub <- getSubscriptionsByCustomerId cid -&- ExpandParams ["data.customer"]
+        void $ deletePlan planid
+        void $ deleteCustomer cid
+        return sub
+      result `shouldSatisfy` isRight
+    it "Succesfully retrieves a Customer's Subscriptions" $ do
+      planid <- makePlanId
+      result <- stripe $ do
+        Customer { customerId = cid } <- createCustomer
+        void $ createPlan planid
+                        (Amount 0) -- free plan
+                        USD
+                        Month
+                        (PlanName "sample plan")
+        void $ createSubscription cid planid
+        sub <- getSubscriptionsByCustomerId cid
+        void $ deletePlan planid
+        void $ deleteCustomer cid
+        return sub
+      result `shouldSatisfy` isRight
     it "Succesfully retrieves all Subscriptions expanded" $ do
       planid <- makePlanId
       result <- stripe $ do

--- a/stripe-tests/tests/Web/Stripe/Test/Subscription.hs
+++ b/stripe-tests/tests/Web/Stripe/Test/Subscription.hs
@@ -62,7 +62,7 @@ subscriptionTests stripe = do
         void $ deleteCustomer cid
         return sub
       result `shouldSatisfy` isRight
-    it "Succesfully retrieves a Customer's Subscriptions expanded" $ do
+    it "Succesfully retrieves all Subscriptions expanded" $ do
       planid <- makePlanId
       result <- stripe $ do
         Customer { customerId = cid } <- createCustomer
@@ -72,12 +72,12 @@ subscriptionTests stripe = do
                         Month
                         (PlanName "sample plan")
         void $ createSubscription cid planid
-        sub <- getSubscriptions cid -&- ExpandParams ["data.customer"]
+        sub <- getSubscriptions -&- ExpandParams ["data.customer"]
         void $ deletePlan planid
         void $ deleteCustomer cid
         return sub
       result `shouldSatisfy` isRight
-    it "Succesfully retrieves a Customer's Subscriptions" $ do
+    it "Succesfully retrieves all Subscriptions" $ do
       planid <- makePlanId
       result <- stripe $ do
         Customer { customerId = cid } <- createCustomer
@@ -87,7 +87,7 @@ subscriptionTests stripe = do
                         Month
                         (PlanName "sample plan")
         void $ createSubscription cid planid
-        sub <- getSubscriptions cid
+        sub <- getSubscriptions
         void $ deletePlan planid
         void $ deleteCustomer cid
         return sub


### PR DESCRIPTION
This renames the current `getSubscriptions` to `getSubscriptionsByCustomerId` and introduces a new `getSubscriptions`:

``` haskell
-- | Retrieve all active `Subscription`s
getSubscriptions
    :: StripeRequest GetSubscriptions
```

which retrieves all the subscriptions (for all customers). 
Fixes #83 