### PR TITLE
Implement http-client backend for stripe requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
     - env: GHCVER=ghc763
     - env: GHCVER=ghc783
     - env: GHCVER=ghc784
+    - env: GHCVER=ghc801
+    - env: GHCVER=ghc802
+    - env: GHCVER=ghc822
     - env: GHCVER=ghcHEAD
   allow_failures:
     - env: GHCVER=ghc742
@@ -17,6 +20,9 @@ matrix:
     - env: GHCVER=ghc783
     - env: GHCVER=ghc784
     - env: GHCVER=ghc7103
+    - env: GHCVER=ghc801
+    - env: GHCVER=ghc802
+    - env: GHCVER=ghc822
     - env: GHCVER=ghcHEAD
 
 before_install:
@@ -25,4 +31,3 @@ before_install:
 
 script:
  - nix-build -A stripe-haskell --argstr compiler $GHCVER
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,6 @@ packages:
 - stripe-core/
 - stripe-haskell/
 - stripe-http-streams/
+- stripe-http-client/
 - stripe-tests/
 resolver: lts-9.5

--- a/stripe-http-client/LICENSE
+++ b/stripe-http-client/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Christopher Reichert
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/stripe-http-client/Setup.hs
+++ b/stripe-http-client/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/stripe-http-client/src/Web/Stripe/Client/HttpClient.hs
+++ b/stripe-http-client/src/Web/Stripe/Client/HttpClient.hs
@@ -138,13 +138,13 @@ m2m S.GET    = Http.methodGet
 m2m S.POST   = Http.methodPost
 m2m S.DELETE = Http.methodDelete
 
--- This function is used instead of http-client's 'urlEncodedBody' so that
---
+-- | This function is used instead of http-client's built-in 'urlEncodedBody' as
+-- the request method is set explicitly to POST in 'urlEncodeBody' but Stripe
+-- uses POST\/PUT\/DELETE. A PR should be submitted to http-client to fix
+-- eventually.
 urlEncodeBody :: [(ByteString, ByteString)] -> Request -> Request
 urlEncodeBody headers req = req {
       requestBody = RequestBodyLBS (BSL.fromChunks body)
-    --
-    -- , method = "POST"
     , requestHeaders =
         ("Content-Type", "application/x-www-form-urlencoded")
       : filter (\(x, _) -> x /= "Content-Type") (requestHeaders req)

--- a/stripe-http-client/src/Web/Stripe/Client/HttpClient.hs
+++ b/stripe-http-client/src/Web/Stripe/Client/HttpClient.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Web.Stripe.Client.HttpClient
+       (
+         StripeRequest(..)
+       , StripeError(..)
+       , StripeConfig(..)
+
+       , stripe
+       , stripeManager
+       , stripeConn
+
+         -- * low-level
+       , withConnection
+       , withManager
+       , callAPI
+
+       ) where
+
+import qualified Control.Arrow
+import qualified Data.ByteString.Lazy     as BSL
+import qualified Data.Text.Encoding       as TE
+import qualified Network.HTTP.Types       as Http
+
+import Data.Aeson               as A
+import Data.ByteString          (ByteString)
+import Data.Monoid              ((<>))
+import Network.HTTP.Client      as Http hiding (withManager)
+import Network.HTTP.Client.TLS  as TLS
+
+import qualified Web.Stripe.StripeRequest as S
+
+import Web.Stripe.Client (APIVersion (..), StripeConfig (..),
+                          StripeError (..), StripeKey (..),
+                          StripeRequest, StripeReturn,
+                          attemptDecode, handleStream,
+                          parseFail, toBytestring, unknownCode)
+
+
+-- | Create a request to 'Stripe's API.
+--
+-- This function uses the global TLS manager from @http-client-tls@
+-- via 'getGlobalManager'.
+stripe :: FromJSON (StripeReturn a)
+       => StripeConfig
+       -> StripeRequest a
+       -> IO (Either StripeError (StripeReturn a))
+stripe config request = do
+    man <- TLS.getGlobalManager
+    callAPI man fromJSON config request
+
+-- | Create a request to 'Stripe's API using a 'Manager'.
+stripeManager :: FromJSON (StripeReturn a)
+              => Manager
+              -> StripeConfig
+              -> StripeRequest a
+              -> IO (Either StripeError (StripeReturn a))
+stripeManager manager config request = callAPI manager fromJSON config request
+
+-- | Create a request to 'Stripe's API using a 'Manager'.
+--
+-- This function is used to maintain compatibility w/
+-- @stripe-http-streams@. However, the terminology in @http-streams@
+-- uses 'Connection' whereas @http-client@ uses connection 'Manager'.
+stripeConn :: FromJSON (StripeReturn a)
+           => Manager
+           -> StripeConfig
+           -> StripeRequest a
+           -> IO (Either StripeError (StripeReturn a))
+stripeConn = stripeManager
+
+withConnection :: (Manager -> IO (Either StripeError a))
+               -> IO (Either StripeError a)
+withConnection = withManager
+
+withManager :: (Manager -> IO (Either StripeError a))
+            -> IO (Either StripeError a)
+withManager m = do
+
+    -- @http-client@ has a set of deprecated `withManager` functions
+    -- that are not necessary to safely prevent a 'Manager' from
+    -- leaking resources. "Manager's will be closed and shutdown
+    -- automatically (and safely) via gargage collection.
+    manager <- TLS.getGlobalManager
+    m manager
+
+-- | Create a request to 'Stripe's API using an existing 'Manager'
+--
+-- This is a low-level function. In most cases you probably want to
+-- use 'stripe' or 'stripeManager'.
+callAPI :: Manager
+        -> (Value -> Result b)
+        -> StripeConfig
+        -> StripeRequest a
+        -> IO (Either StripeError b)
+callAPI man fromJSON' config stripeRequest = do
+
+    res <- httpLbs mkStripeRequest man
+
+    let status = Http.statusCode (Http.responseStatus res)
+
+    if not (attemptDecode status) then
+        return unknownCode
+
+    else do
+        case A.eitherDecode (Http.responseBody res) of
+            Left e  -> pure $ parseFail e
+            Right a -> pure $ handleStream fromJSON' status $ return a
+  where
+    mkStripeRequest =
+
+        let req = Http.applyBasicAuth (getStripeKey (secretKey config)) mempty $
+                  defaultRequest {
+                    Http.method = m2m (S.method stripeRequest)
+                  , Http.secure = True
+                  , Http.host = "api.stripe.com"
+                  , Http.port = 443
+                  , Http.path = "/v1/" <> TE.encodeUtf8 (S.endpoint stripeRequest)
+                  , Http.requestHeaders = [
+                        ("Stripe-Version", toBytestring stripeVersion)
+                      , ("Connection", "Keep-Alive")
+                      ]
+                  , Http.checkResponse = \_ _ -> return ()
+                  }
+
+            stripeQueryParams = fmap
+                                  (Control.Arrow.second Just)
+                                  (S.queryParams stripeRequest)
+
+        in if S.GET == S.method stripeRequest then
+               Http.setQueryString stripeQueryParams req
+           else
+               urlEncodeBody (S.queryParams stripeRequest) req
+
+m2m :: S.Method -> Http.Method
+m2m S.GET    = Http.methodGet
+m2m S.POST   = Http.methodPost
+m2m S.DELETE = Http.methodDelete
+
+-- This function is used instead of http-client's 'urlEncodedBody' so that
+--
+urlEncodeBody :: [(ByteString, ByteString)] -> Request -> Request
+urlEncodeBody headers req = req {
+      requestBody = RequestBodyLBS (BSL.fromChunks body)
+    --
+    -- , method = "POST"
+    , requestHeaders =
+        ("Content-Type", "application/x-www-form-urlencoded")
+      : filter (\(x, _) -> x /= "Content-Type") (requestHeaders req)
+    }
+  where
+    body = pure (Http.renderSimpleQuery False headers)
+
+stripeVersion :: APIVersion
+stripeVersion = V20141007

--- a/stripe-http-client/stripe-http-client.cabal
+++ b/stripe-http-client/stripe-http-client.cabal
@@ -1,0 +1,53 @@
+name:                stripe-http-client
+version:             0.1
+license:             MIT
+license-file:        LICENSE
+author:              Christopher Reichert
+synopsis:            Stripe API for Haskell - http-client backend
+maintainer:          creichert07@gmail.com
+copyright:           Copyright (c) 2018 Christopher Reichert
+category:            Web
+build-type:          Simple
+cabal-version:       >=1.10
+Description:
+    .
+    <<https://stripe.com/img/navigation/logo@2x.png>>
+    .
+    [Access Stripe API using http-client]
+    This package provides access to the Stripe API using `stripe-core`
+    and `http-client`. See also the `stripe` package.
+
+library
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+  exposed-modules:     Web.Stripe.Client.HttpClient
+  ghc-options:         -Wall
+  other-extensions:    OverloadedStrings
+                       RecordWildCards
+  build-depends:         base            >= 4.7  && < 5
+                       , bytestring      >= 0.10 && < 0.11
+                       , text            >= 1.1  && < 1.3
+                       , aeson           >= 0.8 && < 0.10 || >= 0.11 && < 1.3
+                       , http-client
+                       , http-client-tls
+                       , http-types
+                       , stripe-core
+
+Test-Suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   tests
+    default-language: Haskell2010
+    build-depends:    base                >= 4.7  && < 5
+                    , free                >= 4.10 && < 4.13
+                    , hspec               >= 2.1.0 && < 2.5
+                    , stripe-core
+                    , stripe-tests
+                    , http-client
+                    , stripe-http-client
+    ghc-options:      -Wall -threaded -rtsopts
+
+source-repository head
+  type:     git
+  subdir:   stripe-http-client
+  location: git://github.com/dmjio/stripe-haskell.git

--- a/stripe-http-client/tests/Main.hs
+++ b/stripe-http-client/tests/Main.hs
@@ -1,0 +1,32 @@
+module Main where
+
+import Control.Monad.Trans.Free       (FreeF(..), FreeT(..))
+import Network.HTTP.Client
+import Web.Stripe.Client              (StripeConfig(..), StripeError(..))
+import Web.Stripe.Client.HttpClient   (withConnection, callAPI)
+import Web.Stripe.Test.AllTests       (allTests)
+import Web.Stripe.Test.Prelude        (Stripe, StripeRequestF(..))
+
+main :: IO ()
+main = allTests runStripe
+
+runStripe :: StripeConfig
+          -> Stripe a
+          -> IO (Either StripeError a)
+runStripe config stripe =
+  withConnection $ \conn ->
+    runStripe' conn config stripe
+
+runStripe' :: Manager
+           -> StripeConfig
+           -> Stripe a
+           -> IO (Either StripeError a)
+runStripe' manager config (FreeT m) =
+  do f <- m
+     case f of
+       (Pure a) -> return (Right a)
+       (Free (StripeRequestF req decode')) ->
+         do r <- callAPI manager decode' config req
+            case r of
+              (Left e) ->  return (Left e)
+              (Right next) -> runStripe' manager config next


### PR DESCRIPTION
fixes #90 

This is some initial work I've done to implement an `http-client` backend for stripe requests. I wanted to get some feedback before I commit too much time to "finalizing" it for merge.

**Notes:**
- I used `http-client` instead of `http-conduit`. I don't use `http-conduit` much myself and don't really know yet what a `stripe-http-conduit` library may look like.
- I add `stripeConn` and `withConnection` for API compatibility so that existing clients using stripe-http-streams could plug this in without any necessary changes. However, http-client's terminology regarding "connections" is different than http-streams. I'm considering adding DEPRECATED pragmas to these specific functions to get people to use the `stripeManager` and `withManager` function to avoid confusion. I don't have strong feelings on this as I primary use `stripeManager`.
- The main function `stripe` uses an http-client "global" manager (IORef Manager) defined from http-client-tls. I feel like this is good for perf so managers aren't created often.
- I need to add a little more documentation on why using `newManager` (as opposed to http-client's deprecated `withManager` is safe with resources). 
- I may make a few coding style changes to the HttpClient module to be more consistent w/ stripe-http-streams package.

**Follow-Up:**
- As I mentioned in #90, I want to add a flag to the `stripe-haskell` package for this backend. Not sure what the best way to go about the import is (CPP or creating a new `Web.Stripe.Client` module in stripe-http-streams & stripe-http-client`

**Initial test results**
```
Failures:

  tests/Web/Stripe/Test/Event.hs:15: 
  1) Event tests Succesfully retrieves events
       predicate failed on: Left (StripeError {errorType = ParseFailure, errorMsg = "key \"evidence_due_by\" not present", errorCode = Nothing, errorParam = Nothing, errorHTTP = Nothing})

Randomized with seed 1531494023

Finished in 193.2520 seconds
89 examples, 1 failure
```