### PR TITLE
Allow aeson-1.3

### DIFF
--- a/stripe-core/stripe-core.cabal
+++ b/stripe-core/stripe-core.cabal
@@ -20,7 +20,7 @@ Description:
 
 library
   hs-source-dirs:      src
-  build-depends:       aeson                >= 0.8 && < 0.10 || >= 0.11 && < 1.3
+  build-depends:       aeson                >= 0.8 && < 0.10 || >= 0.11 && < 1.4
                      , base                 >= 4.7   && < 5
                      , bytestring           >= 0.10  && < 0.11
                      , mtl                  >= 2.1.2 && < 2.3

--- a/stripe-http-client/stripe-http-client.cabal
+++ b/stripe-http-client/stripe-http-client.cabal
@@ -27,7 +27,7 @@ library
   build-depends:         base            >= 4.7  && < 5
                        , bytestring      >= 0.10 && < 0.11
                        , text            >= 1.1  && < 1.3
-                       , aeson           >= 0.8 && < 0.10 || >= 0.11 && < 1.3
+                       , aeson           >= 0.8 && < 0.10 || >= 0.11 && < 1.4
                        , http-client
                        , http-client-tls
                        , http-types

--- a/stripe-http-streams/stripe-http-streams.cabal
+++ b/stripe-http-streams/stripe-http-streams.cabal
@@ -22,7 +22,7 @@ library
   exposed-modules:     Web.Stripe.Client.HttpStreams
   other-extensions:    OverloadedStrings, RecordWildCards
   build-depends:         base         >= 4.7  && < 5
-                       , aeson        >= 0.8 && < 0.10 || >= 0.11 && < 1.3
+                       , aeson        >= 0.8 && < 0.10 || >= 0.11 && < 1.4
                        , bytestring   >= 0.10 && < 0.11
                        , HsOpenSSL    >= 0.11 && < 0.12
                        , http-streams >= 0.7  && < 0.9

--- a/stripe-tests/stripe-tests.cabal
+++ b/stripe-tests/stripe-tests.cabal
@@ -22,7 +22,7 @@ Description:
 
 library
   hs-source-dirs:      tests
-  build-depends:       aeson                >= 0.8 && < 0.10 || >= 0.11 && < 1.3
+  build-depends:       aeson                >= 0.8 && < 0.10 || >= 0.11 && < 1.4
                      , base                 >= 4.7   && < 5
                      , bytestring           >= 0.10  && < 0.11
                      , free                 >= 4.10  && < 6


### PR DESCRIPTION
This builds for me, though I am not yet actually using the stripe library.  But it is hard to see why it would be unsafe.