### PR TITLE
Bump to 8.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
     - env: GHCVER=ghc802
     - env: GHCVER=ghc822
     - env: GHCVER=ghc842
+    - env: GHCVER=ghc844
+    - env: GHCVER=ghc861
     - env: GHCVER=ghcHEAD
   allow_failures:
     - env: GHCVER=ghc802

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc843", check ? false }:
+{ compiler ? "ghc844", check ? false }:
 let
    config = {
      packageOverrides = pkgs: with pkgs.haskell.lib; {


### PR DESCRIPTION
Adds `8.4.4` to travis, builds `8.4.4` by default.