### PR TITLE
Fix typo charge.failed in FromJSON EventType

### DIFF
--- a/stripe-core/src/Web/Stripe/Types.hs
+++ b/stripe-core/src/Web/Stripe/Types.hs
@@ -1733,7 +1733,7 @@ instance FromJSON EventType where
    parseJSON (String "application_fee.refunded") = pure ApplicationFeeRefundedEvent
    parseJSON (String "balance.available") = pure BalanceAvailableEvent
    parseJSON (String "charge.succeeded") = pure ChargeSucceededEvent
-   parseJSON (String "chage.failed") = pure ChargeFailedEvent
+   parseJSON (String "charge.failed") = pure ChargeFailedEvent
    parseJSON (String "charge.refunded") = pure ChargeRefundedEvent
    parseJSON (String "charge.captured") = pure ChargeCapturedEvent
    parseJSON (String "charge.updated") = pure ChargeUpdatedEvent


### PR DESCRIPTION
Fairly self explanatory: I was receiving an `UnknownEvent` type, and noticed there was an "r" missing.