### PR TITLE
Fix dependencies and versions in Nix expressions

### DIFF
--- a/stripe-core/default.nix
+++ b/stripe-core/default.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "stripe-core";
-  version = "2.4.1";
+  version = "2.6.2";
   src = ./.;
   libraryHaskellDepends = [
     aeson base bytestring mtl text time transformers

--- a/stripe-haskell/default.nix
+++ b/stripe-haskell/default.nix
@@ -1,9 +1,9 @@
-{ mkDerivation, base, stdenv, stripe-core, stripe-http-streams, stripe-http-client }:
+{ mkDerivation, base, stdenv, stripe-core, stripe-http-client }:
 mkDerivation {
   pname = "stripe-haskell";
-  version = "2.4.1";
+  version = "2.6.2";
   src = ./.;
-  libraryHaskellDepends = [ base stripe-core stripe-http-streams stripe-http-client ];
+  libraryHaskellDepends = [ base stripe-core stripe-http-client ];
   homepage = "https://github.com/dmjio/stripe";
   description = "Stripe API for Haskell";
   license = stdenv.lib.licenses.mit;

--- a/stripe-http-client/default.nix
+++ b/stripe-http-client/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "stripe-http-client";
-  version = "2.4.1";
+  version = "2.6.2";
   src = ./.;
   libraryHaskellDepends = [
     aeson base bytestring http-client http-client-tls http-types

--- a/stripe-http-streams/default.nix
+++ b/stripe-http-streams/default.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "stripe-http-streams";
-  version = "2.4.1";
+  version = "2.5.0";
   src = ./.;
   libraryHaskellDepends = [
     aeson base bytestring HsOpenSSL http-streams io-streams stripe-core

--- a/stripe-tests/default.nix
+++ b/stripe-tests/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "stripe-tests";
-  version = "2.4.1";
+  version = "2.6.2";
   src = ./.;
   libraryHaskellDepends = [
     aeson base bytestring free hspec hspec-core mtl random stripe-core


### PR DESCRIPTION
The version numbers in all of the default.nix files were lagging behind
the version numbers stated in the cabal files. This mismatch was causing
some confusing behaviour when I tried to build these packages locally.

I refreshed the versions and dependencies by running cabal2nix in each
of the sub-projects.