### PR TITLE
Align CC brands with Stripe API

### DIFF
--- a/stripe-core/src/Web/Stripe/Types.hs
+++ b/stripe-core/src/Web/Stripe/Types.hs
@@ -1,10 +1,12 @@
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE DeriveDataTypeable   #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 ------------------------------------------------------------------------------
 -- |
 -- Module      : Web.Stripe.Types
@@ -361,25 +363,32 @@ newtype IsVerified = IsVerified { getVerified :: Bool }
 
 ------------------------------------------------------------------------------
 -- | Credit / Debit Card Brand
-data Brand = Visa
-           | AMEX
-           | MasterCard
-           | Discover
-           | JCB
-           | DinersClub
-           | Unknown
-             deriving (Read, Show, Eq, Ord, Data, Typeable)
+--
+-- https://stripe.com/docs/api/cards/object
+data Brand =
+    AMEX
+  | DinersClub
+  | Discover
+  | JCB
+  | MasterCard
+  | UnionPay
+  | Visa
+  | Unknown
+  deriving (Read, Show, Eq, Ord, Data, Typeable)
 
 ------------------------------------------------------------------------------
 -- | JSON Instance for `Brand`
 instance FromJSON Brand where
-   parseJSON (String "American Express") = pure AMEX
-   parseJSON (String "MasterCard") = pure MasterCard
-   parseJSON (String "Discover") = pure Discover
-   parseJSON (String "JCB") = pure JCB
-   parseJSON (String "Visa") = pure Visa
-   parseJSON (String "DinersClub") = pure DinersClub
-   parseJSON _ = mzero
+  parseJSON = \case
+    String "American Express" -> pure AMEX
+    String "Diners Club"      -> pure DinersClub
+    String "Discover"         -> pure Discover
+    String "JCB"              -> pure JCB
+    String "MasterCard"       -> pure MasterCard
+    String "UnionPay"         -> pure UnionPay
+    String "Visa"             -> pure Visa
+    String "Unknown"          -> pure Unknown
+    brand                     -> fail $ "Failed to parse brand: " <> show brand
 
 ------------------------------------------------------------------------------
 -- | `Card` Object

--- a/stripe-core/src/Web/Stripe/Types.hs
+++ b/stripe-core/src/Web/Stripe/Types.hs
@@ -18,21 +18,25 @@
 ------------------------------------------------------------------------------
 module Web.Stripe.Types where
 ------------------------------------------------------------------------------
-import           Control.Applicative (pure, (<$>), (<*>), (<|>))
-import           Control.Monad       (mzero)
-import           Data.Aeson          (FromJSON (parseJSON), ToJSON(..),
-                                      Value (String, Object, Bool), (.:),
-                                      (.:?))
-import           Data.Aeson.Types    (typeMismatch)
-import           Data.Data           (Data, Typeable)
+import Control.Applicative (pure, (<$>), (<*>), (<|>))
+import Control.Monad (mzero)
+import Data.Aeson
+       ( FromJSON(parseJSON)
+       , ToJSON(..)
+       , Value(Bool, Object, String)
+       , (.:)
+       , (.:?)
+       )
+import Data.Aeson.Types (typeMismatch)
+import Data.Data (Data, Typeable)
 import qualified Data.HashMap.Strict as H
-import           Data.Ratio          ((%))
-import           Data.Text           (Text)
-import           Data.Time           (UTCTime)
-import           Numeric             (fromRat, showFFloat)
-import           Text.Read           (lexP, pfail)
-import qualified Text.Read           as R
-import           Web.Stripe.Util     (fromSeconds)
+import Data.Ratio ((%))
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import Numeric (fromRat, showFFloat)
+import Text.Read (lexP, pfail)
+import qualified Text.Read as R
+import Web.Stripe.Util (fromSeconds)
 ------------------------------------------------------------------------------
 
 ------------------------------------------------------------------------------
@@ -1251,7 +1255,7 @@ data BankAccountStatus =
 ------------------------------------------------------------------------------
 -- | `BankAccountStatus` JSON instance
 instance FromJSON BankAccountStatus where
-   parseJSON (String "new") = pure $ New
+   parseJSON (String "new") = pure New
    parseJSON (String "validated") = pure Validated
    parseJSON (String "verified") = pure Verified
    parseJSON (String "errored") = pure Errored
@@ -2021,7 +2025,7 @@ newtype MetaData = MetaData [ (Text,Text) ]
   deriving (Read, Show, Eq, Ord, Data, Typeable)
 
 instance FromJSON MetaData where
-  parseJSON j = (MetaData . H.toList) <$> (parseJSON j)
+  parseJSON j = MetaData . H.toList <$> parseJSON j
 
 ------------------------------------------------------------------------------
 -- | Type of Expansion Parameters for use on `Stripe` objects
@@ -2391,7 +2395,7 @@ data BitcoinReceiver = BitcoinReceiver {
     ,  btcMetadata              :: MetaData
     ,  btcRefundAddress         :: Maybe Text
     ,  btcTransactions          :: Maybe Transactions
-    ,  btcPayment               :: Maybe PaymentId 
+    ,  btcPayment               :: Maybe PaymentId
     ,  btcCustomer              :: Maybe CustomerId
     } deriving (Show, Eq)
 
@@ -2400,23 +2404,23 @@ data BitcoinReceiver = BitcoinReceiver {
 instance FromJSON BitcoinReceiver where
    parseJSON (Object o) =
      BitcoinReceiver <$> (BitcoinReceiverId <$> o .: "id")
-                     <*> o .: "object"  
-                     <*> (fromSeconds <$> o .: "created") 
-                     <*> o .: "livemode"  
-                     <*> o .: "active"  
-                     <*> o .: "amount"  
-                     <*> o .: "amount_received"  
-                     <*> o .: "bitcoin_amount"  
-                     <*> o .: "bitcoin_amount_received"  
-                     <*> o .: "bitcoin_uri"  
-                     <*> o .: "currency"  
-                     <*> o .: "filled"  
-                     <*> o .: "inbound_address"  
-                     <*> o .: "uncaptured_funds"  
-                     <*> o .:? "description"  
-                     <*> o .: "email"  
+                     <*> o .: "object"
+                     <*> (fromSeconds <$> o .: "created")
+                     <*> o .: "livemode"
+                     <*> o .: "active"
+                     <*> o .: "amount"
+                     <*> o .: "amount_received"
+                     <*> o .: "bitcoin_amount"
+                     <*> o .: "bitcoin_amount_received"
+                     <*> o .: "bitcoin_uri"
+                     <*> o .: "currency"
+                     <*> o .: "filled"
+                     <*> o .: "inbound_address"
+                     <*> o .: "uncaptured_funds"
+                     <*> o .:? "description"
+                     <*> o .: "email"
                      <*> (MetaData . H.toList <$> o .: "metadata")
-                     <*> o .:? "refund_address"  
+                     <*> o .:? "refund_address"
                      <*> o .:? "transactions"
                      <*> (fmap PaymentId <$> o .:? "payment")
                      <*> (fmap CustomerId <$> o .:? "customer")
@@ -2436,11 +2440,11 @@ data Transactions = Transactions {
 -- | Bitcoin Transactions data
 instance FromJSON Transactions where
    parseJSON (Object o) =
-     Transactions <$> o .: "object"  
-                  <*> o .: "total_count"  
-                  <*> o .: "has_more"  
-                  <*> o .: "url"  
-                  <*> o .: "data"  
+     Transactions <$> o .: "object"
+                  <*> o .: "total_count"
+                  <*> o .: "has_more"
+                  <*> o .: "url"
+                  <*> o .: "data"
    parseJSON _ = mzero
 
 ------------------------------------------------------------------------------
@@ -2547,4 +2551,4 @@ currencyDivisor cur =
     _   -> error $ "please submit a patch to currencyDivisor for this currency: " ++ show cur
   where
     zeroCurrency = fromIntegral
-    hundred v    = fromRat $ (fromIntegral v) % (100 :: Integer)
+    hundred v    = fromRat $ fromIntegral v % (100 :: Integer)


### PR DESCRIPTION
This commit brings this library's credit/debit card brand parser into
alignment with the values specified in Stripe's API documentation. This
also removes the `mzero` so that the cause of a parse failure here is
more obvious to a library user.

More specifically, this fixes two issues:

1. We incorrectly parsed Diners Club cards, which I believe is the cause
   of [issue #129][0]
2. We did not support UnionPay cards at all.

[0]: https://github.com/dmjio/stripe/issues/129