### PR TITLE
Update bounds for random

### DIFF
--- a/stripe-tests/stripe-tests.cabal
+++ b/stripe-tests/stripe-tests.cabal
@@ -27,7 +27,7 @@ library
                      , bytestring           >= 0.10  && < 0.11
                      , free                 >= 4.10  && < 6
                      , mtl                  >= 2.1.2 && < 2.3
-                     , random               >= 1.1   && < 1.2
+                     , random               >= 1.1   && < 1.3
                      , hspec                >= 2.1.0 && < 2.8
                      , hspec-core           >= 2.1.0 && < 2.8
                      , stripe-core


### PR DESCRIPTION
This PR updates bounds for random-1.2 which was released about a year ago.

If possible a new revision on hackage would be awesome, since it is blocking commercialhaskell/stackage#5474